### PR TITLE
Upgrade to java 11

### DIFF
--- a/cloud/src/main/appengine/app.yaml
+++ b/cloud/src/main/appengine/app.yaml
@@ -1,0 +1,1 @@
+runtime: java11


### PR DESCRIPTION
IDE setup

Download java 11 sdk

Preferences | Build, Execution, Deployment | Compiler | Java Compiler, Project bytecode version set to 11

File | Project Structure | Project, Project SDK set to 11
