### PR TITLE
Modify mission document schema

### DIFF
--- a/src/main/java/org/mozilla/msrp/platform/mission/Mission.kt
+++ b/src/main/java/org/mozilla/msrp/platform/mission/Mission.kt
@@ -10,6 +10,7 @@ package org.mozilla.msrp.platform.mission
  */
 data class Mission(
         val mid: String,
-        val name: String,
-        val description: String
+        val title: String,
+        val description: String,
+        val endpoint: String
 )

--- a/src/main/java/org/mozilla/msrp/platform/mission/MissionController.java
+++ b/src/main/java/org/mozilla/msrp/platform/mission/MissionController.java
@@ -19,6 +19,26 @@ public class MissionController {
 
     /**
      * Fetch user requested missions, and aggregate data that is needed by client
+     *
+     * Request
+     * GET /group/{groupId}/missions
+     *
+     * Response
+     * [
+     *  {
+     *      "mid": "wsF1OHt3CrtrGbAyT8xo",
+     *      "title": "...",
+     *      "description": "...",
+     *      "endpoint": "/mission_daily/wsF1OHt3CrtrGbAyT8xo"
+     *  },
+     *  {
+     *      "mid": "5quMPsVLh0wims22pstL",
+     *      "title": "...",
+     *      "description": "...",
+     *      "endpoint": "/mission_one_shot/wsF1OHt3CrtrGbAyT8xo"
+     *  },
+     * ]
+     *
      * @param groupId id for audience group
      * @return Client-facing mission list
      */

--- a/src/main/java/org/mozilla/msrp/platform/mission/MissionDoc.kt
+++ b/src/main/java/org/mozilla/msrp/platform/mission/MissionDoc.kt
@@ -14,21 +14,35 @@ import java.util.Optional
  */
 data class MissionDoc(
         var mid: String = "",
-        var nameId: String = "",
-        var descriptionId: String = ""
+        var missionName: String = "",
+        var titleId: String = "",
+        var descriptionId: String = "",
+        var missionType: String = ""
 ) {
+    val endpoint = "/$missionType/$mid"
+
     companion object {
         private const val KEY_MID = "mid"
-        private const val KEY_NAME_ID = "nameId"
+        private const val KEY_NAME_ID = "titleId"
         private const val KEY_DESCRIPTION_ID = "descriptionId"
+        private const val KEY_MISSION_TYPE = "missionType"
 
         @JvmStatic
         fun fromDocument(snapshot: DocumentSnapshot): Optional<MissionDoc> {
-            return if (snapshot.areFieldsPresent(listOf(KEY_MID, KEY_NAME_ID, KEY_DESCRIPTION_ID))) {
+            return if (isValidSnapshot(snapshot)) {
                 Optional.ofNullable(snapshot.toObject(MissionDoc::class.java))
             } else {
                 Optional.empty()
             }
+        }
+
+        private fun isValidSnapshot(snapshot: DocumentSnapshot): Boolean {
+            return snapshot.areFieldsPresent(listOf(
+                    KEY_MID,
+                    KEY_NAME_ID,
+                    KEY_DESCRIPTION_ID,
+                    KEY_MISSION_TYPE
+            ))
         }
     }
 }

--- a/src/main/java/org/mozilla/msrp/platform/mission/MissionReferenceDoc.kt
+++ b/src/main/java/org/mozilla/msrp/platform/mission/MissionReferenceDoc.kt
@@ -1,8 +1,6 @@
 package org.mozilla.msrp.platform.mission
 
 import com.google.cloud.firestore.DocumentSnapshot
-import com.google.cloud.firestore.Firestore
-import com.google.cloud.firestore.Query
 import com.google.cloud.firestore.annotation.IgnoreExtraProperties
 import org.mozilla.msrp.platform.firestore.areFieldsPresent
 import java.util.Optional
@@ -33,11 +31,6 @@ data class MissionReferenceDoc(
             } else {
                 Optional.empty()
             }
-        }
-
-        @JvmStatic
-        fun getTargetMissions(ref: MissionReferenceDoc, firestore: Firestore): Query {
-            return firestore.collection(ref.type).whereEqualTo("mid", ref.mid)
         }
     }
 }

--- a/src/main/java/org/mozilla/msrp/platform/mission/MissionService.java
+++ b/src/main/java/org/mozilla/msrp/platform/mission/MissionService.java
@@ -40,14 +40,15 @@ class MissionService {
 
     private Mission convertToMission(MissionDoc missionDoc) {
         // TODO: String & L10N
-        String name = getStringById(missionDoc.getNameId());
+        String name = getStringById(missionDoc.getTitleId());
         String description = getStringById(missionDoc.getDescriptionId());
 
         // TODO: Aggregate mission progress
 
         return new Mission(missionDoc.getMid(),
                 name,
-                description);
+                description,
+                missionDoc.getEndpoint());
     }
 
     /**


### PR DESCRIPTION
When I'm working on join-mission API, I found that client will need a way to specify which mission he'd like to join, a single mid isn't sufficient since we separate missions into multiple collections by mission type.

So I made some changes
1. Original mid looks like "mission_01", "mission_02", I add a new field missionName for this.
2. mid now is a duplicate of document id
3. Add a new field named "endpoint" in mission doc. endpoint is the path to the document, and is also the path of the API endpoint

For example:
collection("daily").doc("wsF1OHt3CrtrGbAyT8xo")
{
    "mid"="wsF1OHt3CrtrGbAyT8xo",
    "missionName"="daily checkin,
    "titleId"="xxx",
    "descriptionId"="yyy",
    **"endpoint"="/daily/wsF1OHt3CrtrGbAyT8xo"**
}

To join a mission, API endpoint will be
POST /missions/daily/wsF1OHt3CrtrGbAyT8xo
