### PR TITLE
Implement a global exception handler

### DIFF
--- a/src/main/java/org/mozilla/msrp/platform/common/exception/ErrorResponseMessage.kt
+++ b/src/main/java/org/mozilla/msrp/platform/common/exception/ErrorResponseMessage.kt
@@ -1,0 +1,3 @@
+package org.mozilla.msrp.platform.common.exception
+
+data class ErrorResponseMessage(val msg: String)

--- a/src/main/java/org/mozilla/msrp/platform/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/java/org/mozilla/msrp/platform/common/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,27 @@
+package org.mozilla.msrp.platform.common.exception
+
+import org.mozilla.msrp.platform.util.logger
+import org.springframework.core.NestedExceptionUtils
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+
+@ControllerAdvice
+class GlobalExceptionHandler {
+
+    val log = logger()
+
+    /**
+     * Default handler
+     */
+    @ExceptionHandler(value = [Exception::class])
+    fun handleException(e: Exception): ResponseEntity<ErrorResponseMessage> {
+        val msg = NestedExceptionUtils.buildMessage("", e)
+        log.info("global uncaught exception: {}", msg)
+        return ResponseEntity(
+                ErrorResponseMessage("internal server error"),
+                HttpStatus.INTERNAL_SERVER_ERROR
+        )
+    }
+}

--- a/src/main/java/org/mozilla/msrp/platform/mission/MissionExceptions.kt
+++ b/src/main/java/org/mozilla/msrp/platform/mission/MissionExceptions.kt
@@ -1,25 +1,12 @@
 package org.mozilla.msrp.platform.mission
 
-import com.google.api.core.ApiFuture
-import com.google.common.util.concurrent.Futures
-import com.google.common.util.concurrent.UncheckedExecutionException
-import java.lang.RuntimeException
-import java.util.concurrent.CancellationException
-
-class MissionDatabaseException(cause: Throwable) : RuntimeException(cause)
-
 /**
- * This function first convert checked exception into either CancellationException or UncheckedExecutionException,
- * then abstract them into higher-level MissionDatabaseException
+ * Still looking for a way to wrap all FirestoreException thrown during the execution of MissionController into
+ * MissionDatabaseException, so global exception handler will only know there's something wrong with the
+ * mission database, instead of knowing anything about Firestore
  */
-fun <T> ApiFuture<T>.getUnchecked(): T {
-    return try {
-        Futures.getUnchecked(this)
-
-    } catch (e: CancellationException) {
-        throw MissionDatabaseException(e)
-
-    } catch (e: UncheckedExecutionException) {
-        throw MissionDatabaseException(e)
-    }
+class MissionDatabaseException : RuntimeException {
+    constructor(msg: String) : super(msg)
+    constructor(cause: Throwable?) : super(cause)
+    constructor(msg: String, cause: Throwable?) : super(msg, cause)
 }


### PR DESCRIPTION
A single application-wide @ControllerAdvice, which will receive all kinds of application-specific exceptions and dispatch to the corresponding handler. There's also a default handler for any unaware error & exception.

To avoid this class grows fat in the future, handlers for different types of exception will be injected instead of embedding in the ExceptionDispatcher class.