### PR TITLE
Add "important" field to mission list response

### DIFF
--- a/src/main/java/org/mozilla/msrp/platform/mission/MissionListItem.kt
+++ b/src/main/java/org/mozilla/msrp/platform/mission/MissionListItem.kt
@@ -1,7 +1,5 @@
 package org.mozilla.msrp.platform.mission
 
-import org.mozilla.msrp.platform.mission.qualifier.MissionProgressDoc
-
 /**
  * (All fields are just draft and are subject to change)
  * Client-facing mission class, this class should contains
@@ -19,5 +17,6 @@ data class MissionListItem(
         val expiredDate: String,
         val status: JoinStatus,
         val minVersion: Int,
-        val progress: Map<String, Any>
+        val progress: Map<String, Any>,
+        val important: Boolean
 )

--- a/src/main/java/org/mozilla/msrp/platform/mission/MissionRepository.kt
+++ b/src/main/java/org/mozilla/msrp/platform/mission/MissionRepository.kt
@@ -29,4 +29,6 @@ interface MissionRepository {
     fun getDailyMissionProgress(uid: String, mid: String): DailyMissionProgressDoc?
     fun updateDailyMissionProgress(progressDoc: MissionProgressDoc)
     fun clearDailyMissionProgress(uid: String, mid: String)
+
+    fun isImportantMission(missionType: String, mid: String): Boolean
 }

--- a/src/main/java/org/mozilla/msrp/platform/mission/MissionRepositoryFirestore.kt
+++ b/src/main/java/org/mozilla/msrp/platform/mission/MissionRepositoryFirestore.kt
@@ -244,6 +244,17 @@ class MissionRepositoryFirestore @Inject internal constructor(
         collection.document().setUnchecked(clearDoc, mapper)
     }
 
+    override fun isImportantMission(missionType: String, mid: String): Boolean {
+        val dataMap = firestore.collection("important_mission")
+                .orderBy("created_timestamp", Query.Direction.DESCENDING)
+                .limit(1)
+                .getResultsUnchecked()
+                .firstOrNull()
+                ?.data ?: return false
+
+        return dataMap["missionType"] == missionType && dataMap["mid"] == mid
+    }
+
     private fun getDailyMissionCollection() =
             firestore.collection("${MissionType.DailyMission.identifier}_progress")
 }

--- a/src/main/java/org/mozilla/msrp/platform/mission/MissionService.kt
+++ b/src/main/java/org/mozilla/msrp/platform/mission/MissionService.kt
@@ -88,6 +88,8 @@ import javax.inject.Named
                 missionDoc.missionTypeEnum
         )
 
+        val important = missionRepository.isImportantMission(missionDoc.missionType, missionDoc.mid)
+
         return MissionListItem(
                 mid = missionDoc.mid,
                 title = name,
@@ -97,7 +99,8 @@ import javax.inject.Named
                 expiredDate = missionDoc.expiredDate,
                 status = joinStatus,
                 minVersion = missionDoc.minVersion,
-                progress = progress?.toProgressResponse() ?: emptyMap()
+                progress = progress?.toProgressResponse() ?: emptyMap(),
+                important = important
         )
     }
 


### PR DESCRIPTION
Each time we want to specify a new important mission, we should add a new record to the collection "important_mission" instead of replacing the current one. Thus we can have a history list of previous important missions.