### PR TITLE
Fix issue where progress data is not presented in the mission list API response after rejoining a mission

### DIFF
--- a/src/main/java/org/mozilla/msrp/platform/mission/qualifier/DailyMissionQualifier.kt
+++ b/src/main/java/org/mozilla/msrp/platform/mission/qualifier/DailyMissionQualifier.kt
@@ -13,7 +13,7 @@ import javax.inject.Named
 
 
 @Named
-class DailyMissionQualifier(val clock: Clock = Clock.systemUTC()) {
+class DailyMissionQualifier(private val clock: Clock = Clock.systemUTC()) {
 
     private val log = logger()
 
@@ -80,7 +80,7 @@ class DailyMissionQualifier(val clock: Clock = Clock.systemUTC()) {
                 uid = uid,
                 mid = mid,
                 joinDate = now,
-                timestamp = 0,
+                timestamp = now,
                 missionType = MissionType.DailyMission.identifier,
                 currentDayCount = 0,
                 totalDays = totalDays


### PR DESCRIPTION
Original implementation assigns 0 to the progress doc timestamp when the user joins the mission. However, in the re-join case, there already exists a quit-record with non-zero timestamp. In order to get the new progress created by re-joining, the new progress doc must have the timestamp larger than that of the quit-record.

The solution is simple, we just need to always assign current time to the record

```
override fun getDailyMissionProgress(
            uid: String,
            mid: String
    ): DailyMissionProgressDoc? {
        val result = collection
                .whereEqualTo("uid", uid)
                .whereEqualTo("mid", mid)
                .orderBy("timestamp", Query.Direction.DESCENDING)
                .limit(1)
                .getResultsUnchecked()
                .firstOrNull()
}
```