### PR TITLE
Standardize the logging format for log-based metrics

### DIFF
--- a/src/main/java/org/mozilla/msrp/platform/metrics/Metrics.kt
+++ b/src/main/java/org/mozilla/msrp/platform/metrics/Metrics.kt
@@ -1,0 +1,20 @@
+package org.mozilla.msrp.platform.metrics
+
+import org.mozilla.msrp.platform.util.logger
+
+class Metrics {
+
+    companion object {
+        const val EVENT_USER_SUSPENDED = "user_suspended"
+        const val EVENT_USER_BIND_FAIL = "user_bind_fail"
+        const val EVENT_REDEEM_FAIL = "redeem_fail"
+        const val EVENT_REDEEM_CONSUMED = "redeem_consumed"
+        const val EVENT_MISSION_JOINED = "mission_joined"
+        const val EVENT_MISSION_CHECK_IN = "mission_check_in"
+
+        @JvmStatic
+        fun event(key: String, value: String = "") {
+            logger().info("$key==$value")
+        }
+    }
+}

--- a/src/main/java/org/mozilla/msrp/platform/mission/MissionController.java
+++ b/src/main/java/org/mozilla/msrp/platform/mission/MissionController.java
@@ -3,6 +3,7 @@ package org.mozilla.msrp.platform.mission;
 import lombok.extern.log4j.Log4j2;
 import org.mozilla.msrp.platform.common.auth.Auth;
 import org.mozilla.msrp.platform.common.auth.JwtHelper;
+import org.mozilla.msrp.platform.metrics.Metrics;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -253,6 +254,7 @@ public class MissionController {
 
         MissionJoinResult result = missionService.joinMission(uid, missionType, mid, zone, locale);
         if (result instanceof MissionJoinResult.Success) {
+            Metrics.event(Metrics.EVENT_MISSION_JOINED, "mid:" + mid);
             MissionJoinResult.Success successResult = (MissionJoinResult.Success) result;
             return ResponseEntity.ok(new MissionJoinResponse.Success(successResult));
 

--- a/src/main/java/org/mozilla/msrp/platform/mission/MissionService.kt
+++ b/src/main/java/org/mozilla/msrp/platform/mission/MissionService.kt
@@ -4,6 +4,7 @@ import org.mozilla.msrp.platform.common.getMessageOrEmpty
 import org.mozilla.msrp.platform.common.getMessageOrNull
 import org.mozilla.msrp.platform.common.isProd
 import org.mozilla.msrp.platform.firestore.stringToLocalDateTime
+import org.mozilla.msrp.platform.metrics.Metrics
 import org.mozilla.msrp.platform.mission.qualifier.MissionProgressDoc
 import org.mozilla.msrp.platform.mission.qualifier.MissionQualifier
 import org.mozilla.msrp.platform.redward.RewardRepository
@@ -449,6 +450,7 @@ class MissionService @Inject constructor(
         // This is ugly but I don't have time to re-write `aggregateMissionListItem` right now.
         // TODO: fix the n*n complexity here :(
         joinedMissions.map {
+            Metrics.event(Metrics.EVENT_MISSION_CHECK_IN, "mid:${it.mid}")
             val progressDoc = updateProgress(uid, it.missionType, it.mid, zone, locale)
             for (missionListItem in joinedMissionListItem) {
                 if (missionListItem.mid == progressDoc?.mid) {

--- a/src/main/java/org/mozilla/msrp/platform/redward/RewardController.kt
+++ b/src/main/java/org/mozilla/msrp/platform/redward/RewardController.kt
@@ -1,6 +1,7 @@
 package org.mozilla.msrp.platform.redward
 
 import org.mozilla.msrp.platform.common.auth.JwtHelper
+import org.mozilla.msrp.platform.metrics.Metrics
 import org.mozilla.msrp.platform.util.logger
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -57,19 +58,19 @@ class RedeemController @Inject constructor(val rewardRepository: RewardRepositor
                 ResponseEntity(RedeemResponse.Success(redeemResult.rewardCouponDoc), HttpStatus.OK)
             }
             is RedeemResult.UsedUp -> {
-                logger.info(redeemResult.debugInfo)
+                Metrics.event(Metrics.EVENT_REDEEM_FAIL, redeemResult.debugInfo)
                 ResponseEntity(RedeemResponse.Fail(redeemResult.message), HttpStatus.NOT_FOUND)
             }
             is RedeemResult.NotReady -> {
-                logger.info(redeemResult.debugInfo)
+                Metrics.event(Metrics.EVENT_REDEEM_FAIL, redeemResult.debugInfo)
                 ResponseEntity(RedeemResponse.Fail(redeemResult.message), HttpStatus.FORBIDDEN)
             }
             is RedeemResult.InvalidReward -> {
-                logger.info(redeemResult.debugInfo)
+                Metrics.event(Metrics.EVENT_REDEEM_FAIL, redeemResult.debugInfo)
                 ResponseEntity(RedeemResponse.Fail(redeemResult.message), HttpStatus.BAD_REQUEST)
             }
             is RedeemResult.Failure -> {
-                logger.error(redeemResult.debugInfo)
+                Metrics.event(Metrics.EVENT_REDEEM_FAIL, redeemResult.debugInfo)
                 ResponseEntity(RedeemResponse.Fail(redeemResult.message), HttpStatus.INTERNAL_SERVER_ERROR)
             }
         }

--- a/src/main/java/org/mozilla/msrp/platform/redward/RewardRepository.kt
+++ b/src/main/java/org/mozilla/msrp/platform/redward/RewardRepository.kt
@@ -9,6 +9,7 @@ import org.mozilla.msrp.platform.firestore.getBatchIteration
 import org.mozilla.msrp.platform.firestore.getResultsUnchecked
 import org.mozilla.msrp.platform.firestore.getUnchecked
 import org.mozilla.msrp.platform.firestore.stringToLocalDateTime
+import org.mozilla.msrp.platform.metrics.Metrics
 import org.mozilla.msrp.platform.mission.JoinStatus
 import org.mozilla.msrp.platform.mission.MissionDoc
 import org.mozilla.msrp.platform.mission.MissionJoinDoc
@@ -118,7 +119,7 @@ open class RewardRepository @Inject constructor(
                         // update MissionJoinDoc
                         val success = missionRepository.updateMissionJoinDocAfterRedeem(uid, missionType, mid, rewardDocId, transaction)
                         if (success && rewardDoc != null) {
-
+                            Metrics.event(Metrics.EVENT_REDEEM_CONSUMED, "mid:$mid")
                             return@runTransaction RedeemResult.Success(rewardDoc, "Reward consumed! ${info(missionJoinDoc)}")
 
                         } else {

--- a/src/main/java/org/mozilla/msrp/platform/user/UserRepository.kt
+++ b/src/main/java/org/mozilla/msrp/platform/user/UserRepository.kt
@@ -8,6 +8,7 @@ import com.google.firebase.auth.FirebaseAuth
 import org.mozilla.msrp.platform.firestore.getResultsUnchecked
 import org.mozilla.msrp.platform.firestore.getUnchecked
 import org.mozilla.msrp.platform.firestore.setUnchecked
+import org.mozilla.msrp.platform.metrics.Metrics
 import org.mozilla.msrp.platform.user.data.UserActivityDoc
 import org.mozilla.msrp.platform.user.data.UserDoc
 import org.mozilla.msrp.platform.util.logger
@@ -82,7 +83,7 @@ class UserRepository @Inject constructor(firestore: Firestore) {
             if (USER_SUSPEND_THRESHOLD == signInCountLast7DAYS) {
                 setUserDocStatus(userDocIdFxA, UserDoc.STATUS_SUSPEND)
                 logUserActivity(userDocIdFxA, UserDoc.STATUS_SUSPEND)
-
+                Metrics.event(Metrics.EVENT_USER_SUSPENDED)
                 logger.info("UserDoc[$userDocIdFxA] has logged in three times per 7 days.")
                 return LoginResponse.UserSuspended("UserDoc[$userDocIdFxA] has logged in three times per 7 days.")
             }


### PR DESCRIPTION
If we use free text, it'll be hard to create custom log-based metrics for monitoring.

There are two possible solutions:
1. Create custom metrics using Stackdriver monitoring API. 
2. Adding reason code in every HTTP response body. 
3. Run a system scan regularly

The first approach needs to add new dependencies.
The second approach will need to change the code structure. For example, some service/repository layers can't provide detail information in Success or Fail cases.
The third approach is straightforward, but it's another engineering effort.
So I choose this simple approach: Use predefine text for log-based metrics. Just like the Telemetry library in our Android app.