### PR TITLE
add stableCloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,20 +2,3 @@ steps:
 - name: 'gcr.io/cloud-builders/gradle:4.6-jdk-8'
   args: ['clean', 'appengineDeploy' ,'-Pmode=${_DEPLOY_TARGET}']
 
-# This step runs MSRP API Test when deploy to stable env
-- name: 'gcr.io/cloud-builders/npm'
-  id: Test
-  entrypoint: /bin/bash
-  secretEnv: ['GOOGLE_API_KEY']
-  args:
-    - -c
-    - '[[ "${_DEPLOY_TARGET}" == "stable" ]] && npm install -g newman && newman run postmanApi/"MSRP Happy Path Automation.postman_collection.json" -e "postmanApi/- STABLE (rocket-dev01).postman_environment.json" --env-var GOOGLE_API_KEY=$$GOOGLE_API_KEY'
-
-# This step provide stable env secrets from cryptographic keys 
-secrets:
-- kmsKeyName: projects/rocket-dev01/locations/global/keyRings/msrpApi/cryptoKeys/cloudbuild-env
-  secretEnv:
-    GOOGLE_API_KEY: CiQAOHzsGBULOZHoncXpvuNNwTz+OmD4op7DW98rP1bVXZnGlgkSUADMs3z+LpIu/C452pLNDdAZd4PljUwfw6BSImc3UKIOVWQ9EgqZ/H2CpDaReRJIrVqNsJOA2vm3hJ/yzMF/TnrmiDkCUUV3JDLLG53dIcz7
-
-
-

--- a/stableCloudBuild.yml
+++ b/stableCloudBuild.yml
@@ -1,0 +1,21 @@
+steps:
+- name: 'gcr.io/cloud-builders/gradle:4.6-jdk-8'
+  args: ['clean', 'appengineDeploy' ,'-Pmode=${_DEPLOY_TARGET}']
+
+# This step runs MSRP API Test when deploy to stable env
+- name: 'gcr.io/cloud-builders/npm'
+  id: Test
+  entrypoint: /bin/bash
+  secretEnv: ['GOOGLE_API_KEY']
+  args:
+    - -c
+    - '[[ "${_DEPLOY_TARGET}" == "stable" ]] && npm install -g newman && newman run postmanApi/"MSRP Happy Path Automation.postman_collection.json" -e "postmanApi/- STABLE (rocket-dev01).postman_environment.json" --env-var GOOGLE_API_KEY=$$GOOGLE_API_KEY'
+
+# This step provide stable env secrets from cryptographic keys 
+secrets:
+- kmsKeyName: projects/rocket-dev01/locations/global/keyRings/msrpApi/cryptoKeys/cloudbuild-env
+  secretEnv:
+    GOOGLE_API_KEY: CiQAOHzsGBULOZHoncXpvuNNwTz+OmD4op7DW98rP1bVXZnGlgkSUADMs3z+LpIu/C452pLNDdAZd4PljUwfw6BSImc3UKIOVWQ9EgqZ/H2CpDaReRJIrVqNsJOA2vm3hJ/yzMF/TnrmiDkCUUV3JDLLG53dIcz7
+
+
+


### PR DESCRIPTION
1.  since cloud build secret env has API limitation refer [this issue](https://stackoverflow.com/questions/56936520/google-cloud-build-doesnt-substitute-values-in-secrets-section-of-cloudbuild-ya) we could not substitute the secret based on different deploy environment
2. A workaround is when dev deploys to stable env we will trigger this customized stableCloudbuild.yaml file.