### PR TITLE
Newman new hard requirement on npm >=v10

### DIFF
--- a/nightlyCloudbuild.yaml
+++ b/nightlyCloudbuild.yaml
@@ -3,7 +3,7 @@ steps:
   args: ['clean', 'appengineDeploy' ,'-Pmode=${_DEPLOY_TARGET}']
 
 # This step runs MSRP API Test when deploy to stable env
-- name: 'gcr.io/cloud-builders/npm'
+- name: 'gcr.io/cloud-builders/npm:node-10.10.0'
   id: Test
   entrypoint: /bin/bash
   args:

--- a/stableCloudbuild.yaml
+++ b/stableCloudbuild.yaml
@@ -3,7 +3,7 @@ steps:
   args: ['clean', 'appengineDeploy' ,'-Pmode=${_DEPLOY_TARGET}']
 
 # This step runs MSRP API Test when deploy to stable env
-- name: 'gcr.io/cloud-builders/npm'
+- name: 'gcr.io/cloud-builders/npm:node-10.10.0'
   id: Test
   entrypoint: /bin/bash
   secretEnv: ['GOOGLE_API_KEY']


### PR DESCRIPTION
1. Fix test failed issue. The root cause is newman has new hard dependency on nodejs version 12 days ago (refer: [To run Newman, ensure that you have Node.js >= v10](https://www.npmjs.com/package/newman) )
2. Run and test local successfully.