### PR TITLE
fix Nightly API test as integration tests folder added

### DIFF
--- a/integrationTest/postmanApi/apiTestNightly.sh
+++ b/integrationTest/postmanApi/apiTestNightly.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 # API test on News 
-newman run postmanApi/collection/VERTICAL.json --folder NEWS -d postmanApi/data/news_data.json -e postmanApi/environment/VERTICAL_NIGHTLY.json
+newman run integrationTest/postmanApi/collection/VERTICAL.json --folder NEWS -d integrationTest/postmanApi/data/news_data.json -e postmanApi/environment/VERTICAL_NIGHTLY.json
 # API Test on Game 
-newman run postmanApi/collection/VERTICAL.json --folder GAME -e postmanApi/environment/VERTICAL_NIGHTLY.json
+newman run integrationTest/postmanApi/collection/VERTICAL.json --folder GAME -e integrationTest/postmanApi/environment/VERTICAL_NIGHTLY.json
 # API Test on Travel
-newman run postmanApi/collection/VERTICAL.json --folder TRAVEL -e postmanApi/environment/VERTICAL_NIGHTLY.json
+newman run integrationTest/postmanApi/collection/VERTICAL.json --folder TRAVEL -e integrationTest/postmanApi/environment/VERTICAL_NIGHTLY.json
 # API Test on Shopping
-newman run postmanApi/collection/VERTICAL.json --folder SHOPPING -e postmanApi/environment/VERTICAL_NIGHTLY.json
+newman run integrationTest/postmanApi/collection/VERTICAL.json --folder SHOPPING -e integrationTest/postmanApi/environment/VERTICAL_NIGHTLY.json

--- a/nightlyCloudbuild.yaml
+++ b/nightlyCloudbuild.yaml
@@ -8,4 +8,4 @@ steps:
   entrypoint: /bin/bash
   args:
     - -c
-    - '[[ "${_DEPLOY_TARGET}" == "nightly" ]] && npm install -g newman && sh postmanApi/apiTestNightly.sh'
+    - '[[ "${_DEPLOY_TARGET}" == "nightly" ]] && npm install -g newman && sh integrationTest/postmanApi/apiTestNightly.sh'


### PR DESCRIPTION
1. Since we reorg integreation tests to new folder, nightly could build yaml and shell script should be changed accordingly.